### PR TITLE
Fix ban expiry date something showing wrong days count

### DIFF
--- a/src/bansystem/util/date/Countdown.php
+++ b/src/bansystem/util/date/Countdown.php
@@ -236,7 +236,7 @@ class Countdown {
             $day--;
         }
         if ($day <= -1) {
-            $day = 30 + $day;
+            $day = intval($to->format("t")) + $day;
             $month--;
         }
         if ($month <= -1) {


### PR DESCRIPTION
This was happening because we were assuming that every month had 30 days.

$to->format("t") is used to get the correct number of days for the current month.